### PR TITLE
Make invalid state not representable

### DIFF
--- a/src/Components.fs
+++ b/src/Components.fs
@@ -79,20 +79,20 @@ type Components =
                     Html.div [
                         prop.className stylesheet.["slot-container"]
                         prop.children [
-                            for (position, tag) in appState.Slots do
+                            for index, tag in appState |> Array.indexed do
                             Html.div [
-                                prop.text (if position = appState.FreePos then "" else tag)
+                                prop.text (if tag = FifteenPuzzle.FreeTag then "" else string tag)
                                 prop.onClick (fun _ ->
                                     setAppState(fun prevState ->
-                                        if FifteenPuzzle.canMove prevState position
-                                        then FifteenPuzzle.slotSelected prevState position tag
+                                        if FifteenPuzzle.canMove prevState index
+                                        then FifteenPuzzle.slotSelected prevState index
                                         else prevState
                                     )
                                 )
                                 prop.className [
-                                    if position = appState.FreePos
+                                    if tag = FifteenPuzzle.FreeTag
                                     then stylesheet.["free-slot"]
-                                    else if FifteenPuzzle.inFinalPosition position tag
+                                    else if FifteenPuzzle.inFinalPosition index tag
                                     then stylesheet.["final-slot"]
                                     else  stylesheet.["slot"]
                                 ]

--- a/src/Components.fs
+++ b/src/Components.fs
@@ -79,7 +79,7 @@ type Components =
                     Html.div [
                         prop.className stylesheet.["slot-container"]
                         prop.children [
-                            for index, tag in appState |> Array.indexed do
+                            for index, tag in appState |> List.indexed do
                             Html.div [
                                 prop.text (if tag = FifteenPuzzle.FreeTag then "" else string tag)
                                 prop.onClick (fun _ ->

--- a/src/FifteenPuzzle.fs
+++ b/src/FifteenPuzzle.fs
@@ -11,17 +11,17 @@ let [<Literal>] RowLength = 4
 let SlotCount = RowCount*RowLength
 let FreeTag = SlotCount
 
-type AppState = int []
+type AppState = int list
 
-let solvedState = [| 1..SlotCount |]
+let solvedState = [ 1..SlotCount ]
 
 let random = Random()
 
 let initialState() : AppState =
-    Array.sortBy (fun _ -> random.NextDouble()) [|1 .. SlotCount|]
+    List.sortBy (fun _ -> random.NextDouble()) [1 .. SlotCount]
 
 let canMove (state: AppState) (index: int)  =
-    let freeIndex = state |> Array.findIndex ((=) FreeTag)
+    let freeIndex = state |> List.findIndex ((=) FreeTag)
     let possibleMoves =
         [ // Left is only possible if not at the beginning of the row
           if index%RowLength > 0 
@@ -41,10 +41,10 @@ let slotSelected (state:AppState) (index: int) =
     if canMove state index
     then 
         let tag = state.[index]
-        [| for t in state do
+        [ for t in state do
             if t = FreeTag then tag
             elif t = tag then FreeTag
-            else t |]
+            else t ]
     else state
 
 let stylesheet = Stylesheet.load "./fitteen-puzzle.module.css"

--- a/src/FifteenPuzzle.fs
+++ b/src/FifteenPuzzle.fs
@@ -8,30 +8,34 @@ type Slot = Position * string
 
 let [<Literal>] RowCount = 4
 let [<Literal>] RowLength = 4
-let FreeTag = RowCount*RowLength
+let SlotCount = RowCount*RowLength
+let FreeTag = SlotCount
 
-let indexToPosition (index: int) =
-    { Row = index / RowLength; Col = index % RowLength }
-
-let positionToIndex (position: Position) =
-    position.Row*RowLength + position.Col
-
-//type AppState = { Slots : Slot list;  FreePos : Position }
 type AppState = int []
 
-let solvedState = [| 1..FreeTag |]
+let solvedState = [| 1..SlotCount |]
 
 let random = Random()
 
 let initialState() : AppState =
-    Array.sortBy (fun _ -> random.NextDouble()) [|1 .. FreeTag|]
+    Array.sortBy (fun _ -> random.NextDouble()) [|1 .. SlotCount|]
 
 let canMove (state: AppState) (index: int)  =
-    let { Row = x1; Col = y1 } = indexToPosition index
-    let { Row = x2; Col = y2 } = indexToPosition (state |> Array.findIndex ((=) FreeTag))
-    let xDiff = abs (x2 - x1)
-    let yDiff = abs (y2 - y1)
-    xDiff + yDiff <= 1
+    let freeIndex = state |> Array.findIndex ((=) FreeTag)
+    let possibleMoves =
+        [ // Left is only possible if not at the beginning of the row
+          if index%RowLength > 0 
+          then index-1
+          // Right is only possible if not at the end of the row
+          if index%RowLength <> 3 
+          then index+1
+          // Up is only possible if not in the first row
+          if index - RowLength >= 0
+          then index - RowLength
+          // Down is only possible if not in the last row
+          if index + RowLength <= SlotCount
+          then index + RowLength ]
+    List.contains freeIndex possibleMoves
 
 let slotSelected (state:AppState) (index: int) =
     if canMove state index

--- a/src/FifteenPuzzle.fs
+++ b/src/FifteenPuzzle.fs
@@ -2,62 +2,69 @@ module FifteenPuzzle
 
 open System
 
-type Position = { X: int; Y: int }
+type Position = { Row: int; Col: int }
 
 type Slot = Position * string
 
-type AppState = { Slots : Slot list;  FreePos : Position }
+let [<Literal>] RowCount = 4
+let [<Literal>] RowLength = 4
+let FreeTag = RowCount*RowLength
+
+let indexToPosition (index: int) =
+    { Row = index / RowLength; Col = index % RowLength }
+
+let positionToIndex (position: Position) =
+    position.Row*RowLength + position.Col
+
+//type AppState = { Slots : Slot list;  FreePos : Position }
+type AppState = 
+    { Tags: int [] } 
+    member appState.FreePos =
+        appState.Tags
+        |> Array.findIndex ((=) FreeTag)
+        |> indexToPosition
+    member appState.Slots =
+        appState.Tags
+        |> Array.mapi (fun index tag ->
+            indexToPosition index, string tag)
 
 let random = Random()
 
 let initialState() : AppState =
-    let randomTags = List.sortBy (fun _ -> random.NextDouble()) [1 .. 16]
-    // generate slot positions
-    [
-        for x in 0 .. 3 do
-        for y in 0 .. 3 do
-        yield { X = x; Y = y }  ]
-    // give each position a random tag, making it a slot
-    |> List.mapi (fun i pos -> pos, string (List.item i randomTags))
-    |> fun slots ->
-        // find the free slot, it has tag "16"
-        let (pos, _) = Seq.find (fun (p, tag) -> tag = "16") slots
-        // return initial state
-        { Slots = slots; FreePos = pos }
+    //{ Tags = [|1..FreeTag|] } // Solved State for testing
+    { Tags = Array.sortBy (fun _ -> random.NextDouble()) [|1 .. FreeTag|] }
 
 let freePositionTag (state:AppState) =
     state.Slots
-    |> List.find (fun (pos, t) -> pos = state.FreePos)
+    |> Array.find (fun (pos, t) -> pos = state.FreePos)
     |> snd
 
-let slotSelected (state:AppState)  (position: Position) (tag: string) =
-    { state with
-        FreePos = position
-        Slots =
-            if position = state.FreePos
-            then state.Slots
-            else
-                state.Slots
-                |> List.map (fun (slotPosition, slotTag) ->
-                    if slotPosition = state.FreePos
-                    then slotPosition, tag
-                    else if slotPosition = position
-                    then
-                        let oldFreePositionTag = freePositionTag state
-                        slotPosition, oldFreePositionTag
-                    else slotPosition, slotTag) }
-
-let stylesheet = Stylesheet.load "./fitteen-puzzle.module.css"
-
-let canMove (state:AppState) (position: Position)  =
-    let { X = x1; Y = y1 } = position
-    let { X = x2; Y = y2 } = state.FreePos
+let canMove (state: AppState) (position: Position)  =
+    let { Row = x1; Col = y1 } = position
+    let { Row = x2; Col = y2 } = state.FreePos
     let xDiff = abs (x2 - x1)
     let yDiff = abs (y2 - y1)
     xDiff + yDiff <= 1
 
+let slotSelected (state:AppState) (position: Position) (tag: string) =
+    let tag = int tag
+    if canMove state position 
+    then 
+        let tags' = 
+            state.Tags
+            |> Array.map (fun t ->
+                if t = FreeTag 
+                then tag
+                elif t = tag
+                then FreeTag
+                else t )
+        { state with Tags = tags' }
+    else state
+
+let stylesheet = Stylesheet.load "./fitteen-puzzle.module.css"
+
 let inFinalPosition (position: Position) (tag: string) =
-    let { X = x; Y = y } = position
+    let { Row = x; Col = y } = position
     (x * 4) + y + 1 = int tag
 
 let gameFinished (state: AppState) =


### PR DESCRIPTION
Hallo Zaid,

I enjoy watching your streams. I always learn something new. Thank you for it. Pleas continue doing it.

As we had some troubles with invalid state yesterday I thought about it a little bit and tried to refactor the core logic so that it is not possible any more. 

The core idea is that one can represent the state as a list of numbers from 1..16 where 16 is the free slot.
In the first commit there is a version where I still calculate `Position` from index and the `canMove` function is not changed. Later I completely refactored it to use just the index in the list. Also, in the beginning I used array because I thought I will mutate the array and swap the clicked tag with the free tag but later I decided not to do it so I went back to using a list.

The drawback of this implementation is that it is probably not 100% intuitive any more, or is it? I don't know.
I would really like your opinion or maybe what other stream watcher think about it.

Of course, it is your stream and I would totally understand if you have some other goals and do not want take so much time for it. Feel free to ignore this pull request. No hard feelings. ☺